### PR TITLE
added support for routing using ngRoute module

### DIFF
--- a/src/angular-gist-embed/services/gistEmbed.js
+++ b/src/angular-gist-embed/services/gistEmbed.js
@@ -46,6 +46,34 @@ angular.module('gist-embed.services')
                     }, 300);
                 })
                 .then(function() {
+                
+                	// register trigger gist on every route change
+                	$rootScope.$on('$viewContentLoaded',function(){
+                		
+                		// as ng-view can be used as class, attribute and tag, this accounts for all cases
+                		// ng-view is selected to ensure gist is run only on the newly added template
+                		var runGist = function(routeTemplates){
+                			angular.forEach(routeTemplates,function(template){
+                				if(template.length > 0){
+                					template.find('[data-gist-id]').gist();
+                				}
+                			});
+                		},
+                		routeTemplates = [];
+                		routeTemplates.push( angular.element('ng-view') );
+                		routeTemplates.push( angular.element('[ng-view]') );
+                		routeTemplates.push( angular.element('.ng-view') );
+                		
+                		// initialize gist on new elements
+                        angular.element(document).ready(function() {
+		
+                            if (typeof(angular.element(document).gist) === 'function') {
+                                runGist(routeTemplates);
+                            }
+                          
+                        });
+                        
+                	});
 
                     // register trigger gist on every template include
                     $rootScope.$on('$includeContentLoaded', function() {


### PR DESCRIPTION
The module currently does not work when routing is done via ngRoute. The reason being the gist function is not being called for the templates that are included after routing is done. Hence added a listener for [$viewContentLoaded](https://docs.angularjs.org/api/ngRoute/directive/ngView#$viewContentLoadedl) event which is fired when the routing template has been fully loaded
